### PR TITLE
Adding support for parsing basic entries in the output of biosdevname -d

### DIFF
--- a/hwinfo/pci/biosdevname.py
+++ b/hwinfo/pci/biosdevname.py
@@ -1,0 +1,17 @@
+"""Module for host related info"""
+
+from hwinfo.util import CommandParser
+
+class BiosdevnameDParser(CommandParser):
+
+    ITEM_SEPERATOR = "\n\n"
+
+    ITEM_REGEXS = [
+        r'BIOS\ device:\ (?P<bios_device>.*)\n',
+        r'Kernel\ name:\ (?P<kernel_name>.*)\n',
+        r'Driver:\ (?P<driver>.*)\n',
+        r'Driver\ version:\ (?P<driver_version>.*)\n',
+        r'Firmware\ version:\ (?P<firmware_version>.*)\n',
+    ]
+
+

--- a/hwinfo/pci/tests/data/biosdevname-d
+++ b/hwinfo/pci/tests/data/biosdevname-d
@@ -1,0 +1,154 @@
+BIOS device: eth0
+Kernel name: eth0
+Permanent MAC: 6C:AE:8B:22:B7:CA
+Assigned MAC : 6C:AE:8B:22:B7:CA
+Driver: igb
+Driver version: 5.2.5
+Firmware version: 1.52.0
+Bus Info: 0000:06:00.0
+PCI name      : 0000:06:00.0
+PCI Slot      : embedded
+SMBIOS Device Type: Ethernet
+SMBIOS Instance: 2
+SMBIOS Label: Intel i350
+sysfs Index: 2
+sysfs Label: Intel i350
+Embedded Index: 1
+
+BIOS device: eth1
+Kernel name: eth1
+Permanent MAC: 6C:AE:8B:22:B7:CB
+Assigned MAC : 6C:AE:8B:22:B7:CB
+Driver: igb
+Driver version: 5.2.5
+Firmware version: 1.52.0
+Bus Info: 0000:06:00.1
+PCI name      : 0000:06:00.1
+PCI Slot      : embedded
+SMBIOS Device Type: Ethernet
+SMBIOS Instance: 3
+SMBIOS Label: Intel i350
+sysfs Index: 3
+sysfs Label: Intel i350
+Embedded Index: 2
+
+BIOS device: eth2
+Kernel name: eth2
+Permanent MAC: 6C:AE:8B:22:B7:CC
+Assigned MAC : 6C:AE:8B:22:B7:CC
+Driver: igb
+Driver version: 5.2.5
+Firmware version: 1.52.0
+Bus Info: 0000:06:00.2
+PCI name      : 0000:06:00.2
+PCI Slot      : embedded
+SMBIOS Device Type: Ethernet
+SMBIOS Instance: 4
+SMBIOS Label: Intel i350
+sysfs Index: 4
+sysfs Label: Intel i350
+Embedded Index: 3
+
+BIOS device: eth3
+Kernel name: eth3
+Permanent MAC: 6C:AE:8B:22:B7:CD
+Assigned MAC : 6C:AE:8B:22:B7:CD
+Driver: igb
+Driver version: 5.2.5
+Firmware version: 1.52.0
+Bus Info: 0000:06:00.3
+PCI name      : 0000:06:00.3
+PCI Slot      : embedded
+SMBIOS Device Type: Ethernet
+SMBIOS Instance: 5
+SMBIOS Label: Intel i350
+sysfs Index: 5
+sysfs Label: Intel i350
+Embedded Index: 4
+
+BIOS device: eth4
+Kernel name: eth4
+Permanent MAC: 5C:F3:FC:36:65:A0
+Assigned MAC : 5C:F3:FC:36:65:A0
+Driver: be2net
+Driver version: 4.6.62.0u
+Firmware version: 4.2.412.0
+Bus Info: 0000:0c:00.0
+PCI name      : 0000:0c:00.0
+PCI Slot      : Unknown
+Index in slot: 1
+
+BIOS device: eth5
+Kernel name: eth5
+Permanent MAC: 5C:F3:FC:36:65:A4
+Assigned MAC : 5C:F3:FC:36:65:A4
+Driver: be2net
+Driver version: 4.6.62.0u
+Firmware version: 4.2.412.0
+Bus Info: 0000:0c:00.1
+PCI name      : 0000:0c:00.1
+PCI Slot      : Unknown
+Index in slot: 2
+
+BIOS device: eth6
+Kernel name: eth6
+Permanent MAC: 00:00:C9:E9:64:E4
+Assigned MAC : 00:00:C9:E9:64:E4
+Driver: be2net
+Driver version: 4.6.62.0u
+Firmware version: 4.2.412.0
+Bus Info: 0000:11:00.0
+PCI name      : 0000:11:00.0
+PCI Slot      : 3
+SMBIOS Label: PCI-Express Slot 3
+Index in slot: 1
+
+BIOS device: eth7
+Kernel name: eth7
+Permanent MAC: 00:00:C9:E9:64:E8
+Assigned MAC : 00:00:C9:E9:64:E8
+Driver: be2net
+Driver version: 4.6.62.0u
+Firmware version: 4.2.412.0
+Bus Info: 0000:11:00.1
+PCI name      : 0000:11:00.1
+PCI Slot      : 3
+SMBIOS Label: PCI-Express Slot 3
+Index in slot: 2
+
+BIOS device: eth8
+Kernel name: usb0
+Permanent MAC: 6E:AE:8B:22:B7:C9
+Assigned MAC : 6E:AE:8B:22:B7:C9
+Driver: cdc_ether
+Driver version: 22-Aug-2005
+Firmware version: CDC Ethernet Device
+Bus Info: usb-0000:00:1d.0-1.1.5
+
+BIOS device: eth9
+Kernel name: vif1.0
+Permanent MAC: FE:FF:FF:FF:FF:FF
+Assigned MAC : FE:FF:FF:FF:FF:FF
+Driver: vif
+Driver version: 
+Firmware version: 
+Bus Info: vif-1-0
+
+BIOS device: eth10
+Kernel name: vif3.0
+Permanent MAC: FE:FF:FF:FF:FF:FF
+Assigned MAC : FE:FF:FF:FF:FF:FF
+Driver: vif
+Driver version: 
+Firmware version: 
+Bus Info: vif-3-0
+
+BIOS device: eth11
+Kernel name: vif6.0
+Permanent MAC: FE:FF:FF:FF:FF:FF
+Assigned MAC : FE:FF:FF:FF:FF:FF
+Driver: vif
+Driver version: 
+Firmware version: 
+Bus Info: vif-6-0
+

--- a/hwinfo/pci/tests/test_biosdevname.py
+++ b/hwinfo/pci/tests/test_biosdevname.py
@@ -1,0 +1,100 @@
+"""Module for unittesting biosdevname methods"""
+
+import unittest
+from hwinfo.pci.biosdevname import *
+
+DATA_DIR = 'hwinfo/pci/tests/data'
+
+class BiosdevnameDSingleDeviceParserTests(unittest.TestCase):
+
+    RAW_DATA = """
+BIOS device: eth0
+Kernel name: eth0
+Permanent MAC: 6C:AE:8B:22:B7:CA
+Assigned MAC : 6C:AE:8B:22:B7:CA
+Driver: igb
+Driver version: 5.2.5
+Firmware version: 1.52.0
+Bus Info: 0000:06:00.0
+PCI name      : 0000:06:00.0
+PCI Slot      : embedded
+SMBIOS Device Type: Ethernet
+SMBIOS Instance: 2
+SMBIOS Label: Intel i350
+sysfs Index: 2
+sysfs Label: Intel i350
+Embedded Index: 1"""
+
+    DATA_REC = {
+        'bios_device': 'eth0',
+        'kernel_name': 'eth0',
+        'permanent_mac': '6C:AE:8B:22:B7:CA',
+        'assigned_mac': '6C:AE:8B:22:B7:CA',
+        'driver': 'igb',
+        'driver_version': '5.2.5',
+        'firmware_version': '1.52.0',
+        'bus_info': '0000:06:00.0',
+        'pci_name': '0000:06:00.0',
+        'smbios_device_type': 'Ethernet',
+        'smbios_instance': '2',
+        'smbios_label': 'Intel i350',
+        'sysfs Index': '2',
+        'sysfs Label': 'Intel i350',
+        'Embedded Index': '1',
+    }
+
+
+    def setUp(self):
+        self.parser = BiosdevnameDParser(self.RAW_DATA)
+
+    def _assert_equal(self, key):
+        rec = self.parser.parse_items()[0]
+        return self.assertEqual(rec[key], self.DATA_REC[key])
+
+    def test_biosdevname_bios_device(self):
+        return self._assert_equal('bios_device')
+
+    def test_biosdevname_kerenl_name(self):
+        return self._assert_equal('kernel_name')
+
+    def test_biosdevname_driver(self):
+        return self._assert_equal('driver')
+
+    def test_biosdevname_driver_version(self):
+        return self._assert_equal('driver_version')
+
+    def test_biosdevname_firmware_version(self):
+        return self._assert_equal('firmware_version')
+
+class BiosdevnameDMultiDeviceTests(unittest.TestCase):
+
+    DATA_FILE = "%s/%s" % (DATA_DIR, 'biosdevname-d')
+
+    def setUp(self):
+        fh = open(self.DATA_FILE)
+        sample_data = fh.read()
+        fh.close()
+        self.parser = BiosdevnameDParser(sample_data)
+
+    def test_parse_correct_number_of_devices(self):
+        items = self.parser.parse_items()
+        self.assertEqual(len(items), 12)
+
+    def test_count_number_of_be2net_devices(self):
+        items = self.parser.parse_items()
+        count = 0
+        for item in items:
+            if item['driver'] == 'be2net':
+                count = count + 1
+
+        self.assertEqual(count, 4)
+
+    def test_driver_versions_match(self):
+        items = self.parser.parse_items()
+        for item in items:
+            if item['driver'] == 'be2net':
+                self.assertEqual(item['driver_version'], '4.6.62.0u')
+                self.assertEqual(item['firmware_version'], '4.2.412.0')
+            elif item['driver'] == 'igb':
+                self.assertEqual(item['driver_version'], '5.2.5')
+                self.assertEqual(item['firmware_version'], '1.52.0')


### PR DESCRIPTION
Signed-off-by: Rob Dobson rob.dobson@citrix.com
