### PR TITLE
Add support for parsing cpuinfo

### DIFF
--- a/hwinfo/host/cpuinfo.py
+++ b/hwinfo/host/cpuinfo.py
@@ -6,6 +6,7 @@ REGEX_TEMPLATE = r'%s([\ \t])+\:\ (?P<%s>.*)'
 
 class CPUInfoParser(CommandParser):
 
+    ITEM_SEPERATOR = "\n\n"
 
     ITEM_REGEXS = [
         REGEX_TEMPLATE % ('processor', 'processor'),

--- a/hwinfo/host/tests/data/cpuinfo
+++ b/hwinfo/host/tests/data/cpuinfo
@@ -1,0 +1,80 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 30
+model name	: Intel(R) Xeon(R) CPU           X3430  @ 2.40GHz
+stepping	: 5
+microcode	: 0x3
+cpu MHz		: 2394.052
+cache size	: 8192 KB
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu de tsc msr pae mce cx8 apic sep mca cmov pat clflush acpi mmx fxsr sse sse2 ss ht syscall nx lm constant_tsc rep_good nopl nonstop_tsc pni monitor vmx est ssse3 cx16 sse4_1 sse4_2 popcnt hypervisor lahf_lm dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 4788.10
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 30
+model name	: Intel(R) Xeon(R) CPU           X3430  @ 2.40GHz
+stepping	: 5
+microcode	: 0x3
+cpu MHz		: 2394.052
+cache size	: 8192 KB
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu de tsc msr pae mce cx8 apic sep mca cmov pat clflush acpi mmx fxsr sse sse2 ss ht syscall nx lm constant_tsc rep_good nopl nonstop_tsc pni monitor vmx est ssse3 cx16 sse4_1 sse4_2 popcnt hypervisor lahf_lm dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 4788.10
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 30
+model name	: Intel(R) Xeon(R) CPU           X3430  @ 2.40GHz
+stepping	: 5
+microcode	: 0x3
+cpu MHz		: 2394.052
+cache size	: 8192 KB
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu de tsc msr pae mce cx8 apic sep mca cmov pat clflush acpi mmx fxsr sse sse2 ss ht syscall nx lm constant_tsc rep_good nopl nonstop_tsc pni monitor vmx est ssse3 cx16 sse4_1 sse4_2 popcnt hypervisor lahf_lm dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 4788.10
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 30
+model name	: Intel(R) Xeon(R) CPU           X3430  @ 2.40GHz
+stepping	: 5
+microcode	: 0x3
+cpu MHz		: 2394.052
+cache size	: 8192 KB
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 11
+wp		: yes
+flags		: fpu de tsc msr pae mce cx8 apic sep mca cmov pat clflush acpi mmx fxsr sse sse2 ss ht syscall nx lm constant_tsc rep_good nopl nonstop_tsc pni monitor vmx est ssse3 cx16 sse4_1 sse4_2 popcnt hypervisor lahf_lm dtherm tpr_shadow vnmi flexpriority ept vpid
+bogomips	: 4788.10
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:
+

--- a/hwinfo/host/tests/test_cpuinfo.py
+++ b/hwinfo/host/tests/test_cpuinfo.py
@@ -56,7 +56,7 @@ power management:
         self.parser = CPUInfoParser(self.DATA.strip())
 
     def _assert_equal(self, key):
-        rec = self.parser.parse()
+        rec = self.parser.parse_items()[0]
         return self.assertEqual(rec[key], self.DATA_REC[key])
 
     def test_cpuinfo_processor(self):
@@ -112,3 +112,17 @@ power management:
 
     def test_address_sizes(self):
         return self._assert_equal('address_sizes')
+
+class CPUInfoMultipleParseTest(unittest.TestCase):
+
+    DATA_FILE = "%s/cpuinfo" % DATA_DIR
+
+    def setUp(self):
+        fh = open(self.DATA_FILE)
+        data = fh.read()
+        fh.close()
+        self.parser = CPUInfoParser(data)
+
+    def test_number_of_processors(self):
+        recs = self.parser.parse_items()
+        self.assertEqual(len(recs), 4)


### PR DESCRIPTION
Uses the output of /proc/cpuinfo to determine what CPUs are present.
