### PR TITLE
Make sure data is sane before dereference

### DIFF
--- a/hwinfo/util/__init__.py
+++ b/hwinfo/util/__init__.py
@@ -33,7 +33,10 @@ class CommandParser(object):
         self.set_seperator(seperator)
 
     def set_data(self, data):
-        self.DATA = data.strip()
+        if data:
+            self.DATA = data.strip()
+        else:
+            self.DATA = ""
 
     def set_regexs(self, regexs):
         if regexs:


### PR DESCRIPTION
I was seeing a case where data was being passed in as None
and causing an exception.  So to be safe, make sure data
is a value before calling data.strip()