### PR TITLE
make python3 compatible the CommandParser().

### DIFF
--- a/hwinfo/util/__init__.py
+++ b/hwinfo/util/__init__.py
@@ -52,7 +52,7 @@ class CommandParser(object):
             matches = [m.groupdict() for m in re.finditer(regex, item)]
             mdicts = combine_dicts(matches)
             if mdicts:
-                rec = dict(rec.items() + mdicts.items())
+                rec = dict(list(rec.items()) + list(mdicts.items()))
         return rec
 
     def parse_items(self):
@@ -60,7 +60,7 @@ class CommandParser(object):
             return [self.parse_item(self.DATA)]
         else:
             recs = []
-            for data in self.DATA.split(self.ITEM_SEPERATOR):
+            for data in self.DATA.decode().split(self.ITEM_SEPERATOR):
                 rec = self.parse_item(data)
                 recs.append(rec)
             return recs


### PR DESCRIPTION
I've used your code to access some pci information and I've realise that I couldn't do with python3.4.

Without checking the complete module, I did the minimal changes to my needs to make it compatible with both, python 2.7 and 3.4. You may like to apply this patch or wait for a bigger check to make it work for both versions (I don't know when and if I would do).

/srgblnch